### PR TITLE
load widget url from site metadata so it doesn't get reset

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,7 @@ module.exports = {
       "A Gatsby starter using the latest Shopify plugin showcasing a store with product overview, individual product pages, and a cart.",
     siteImage: "/default-og-image.jpg",
     twitter: "@gatsbyjs",
+    onwardWidgetUrl:process.env.ONWARD_WIDGET_URL,
   },
   flags: {
     FAST_DEV: true,

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -22,6 +22,7 @@ export function Seo({
           siteDescription
           siteImage
           twitter
+          onwardWidgetUrl
         }
       }
     }
@@ -34,6 +35,7 @@ export function Seo({
     siteDescription,
     siteImage,
     twitter,
+    onwardWidgetUrl,
   } = siteMetadata
 
   const seo = {
@@ -77,7 +79,7 @@ export function Seo({
         href="/apple-touch-icon.png"
       />
 
-      <script src={`${process.env.ONWARD_WIDGET_URL}?shop=${process.env.GATSBY_SHOPIFY_STORE_URL}`} />
+      <script src={`${onwardWidgetUrl}?shop=${process.env.GATSBY_SHOPIFY_STORE_URL}`} />
 
       {/* The following meta tag is for demonstration only and can be removed */}
       {!!process.env.GATSBY_DEMO_STORE && (


### PR DESCRIPTION
The environment variable was being reset after the initial render which initiates a reload of the head since the value changed. Using the site metadata seems to fix that.